### PR TITLE
Use clang in all unixes. GCC 7 on Ubuntu is generating a broken VM.

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -23,6 +23,8 @@ jobs:
         env:
             APPNAME: ${{matrix.variant.appname}}
             VM_EXECUTABLE_NAME: ${{ matrix.variant.vmExecutable }}
+            CC: clang
+            CXX: clang++
         steps:
             - name: Install dependencies
               if: matrix.variant.os == 'ubuntu-18.04'


### PR DESCRIPTION
This issue seems to be related to the FFI.