### PR TITLE
Make sure the GToolkit main is only used when building GToolkit

### DIFF
--- a/osx.cmake
+++ b/osx.cmake
@@ -25,8 +25,13 @@ set(EXTRACTED_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/memoryUnix.c
 )
 
+set(VM_FRONTEND_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/unixMain.c)
+if("${APPNAME}" STREQUAL "GToolkit")
+    set(VM_FRONTEND_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/macMainGToolkit.m)
+endif()
+
 set(VM_FRONTEND_SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/macMainGToolkit.m
+    ${VM_FRONTEND_SOURCES}
     "${CMAKE_CURRENT_SOURCE_DIR}/resources/mac/${APPNAME}.icns"
 )
 

--- a/win32.cmake
+++ b/win32.cmake
@@ -40,8 +40,13 @@ set(VM_FRONTEND_SOURCES_COMMON
     ${Win32Resource}
 )
 
+set(VM_FRONTEND_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/win32Main.c)
+if("${APPNAME}" STREQUAL "GToolkit")
+    set(VM_FRONTEND_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/win32MainGToolkit.c)
+endif()
+
 set(VM_FRONTEND_SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/win32MainGToolkit.c
+    ${VM_FRONTEND_SOURCES}
     ${Win32Manifest}
     ${VM_FRONTEND_SOURCES_COMMON})
 


### PR DESCRIPTION
Use the GToolkit specific main only when building a GToolkit VM, and not when building a Pharo VM. The objective of this pull request is to facilitate a future merge into the Pharo headless branch.